### PR TITLE
返回调整后的图片宽高,因为识别时box的坐标基于此,方便把box转换成原始图的坐标

### DIFF
--- a/packages/common/src/Ocr.ts
+++ b/packages/common/src/Ocr.ts
@@ -23,8 +23,12 @@ export class Ocr {
   }
 
   async detect(image: string, options = {}) {
-    const lineImages = await this.#detection.run(image, options)
+    const { lineImages, resizedImageWidth, resizedImageHeight } = await this.#detection.run(image, options)
     const texts = await this.#recognition.run(lineImages, options)
-    return texts
+    return {
+      texts,
+      resizedImageWidth,
+      resizedImageHeight,
+    }
   }
 }

--- a/packages/common/src/models/Detection.ts
+++ b/packages/common/src/models/Detection.ts
@@ -49,7 +49,11 @@ export class Detection extends ModelBase {
     const lineImages = await splitIntoLineImages(outputImage, inputImage)
     this.debugBoxImage(inputImage, lineImages, 'boxes.jpg')
 
-    return lineImages
+    return {
+      lineImages,
+      resizedImageWidth: image.width,
+      resizedImageHeight: image.height,
+    }
   }
 }
 


### PR DESCRIPTION
本想用 `return [ texts, width, height ];` 数组扩展返回值的

想了想，既然怎么都会影响到返回值的类型，不如直接用对象，这样也方便以后扩展其他的