### PR TITLE
chore: update onnxruntime-node

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@gutenye/ocr-common": "^1.2.0",
     "@gutenye/ocr-models": "^1.2.2",
-    "onnxruntime-node": "^1.17.3-rev.1",
+    "onnxruntime-node": "^1.22.0-rev",
     "sharp": "^0.34.3"
   }
 }


### PR DESCRIPTION
when installing on linux you get the error described here https://github.com/microsoft/onnxruntime/issues/24918#issuecomment-2932742678 so the solution suggested is to use 1.22.0-rev