### PR TITLE
feat(node): accept ImageRawData as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Ocr.create({
   onnxOptions?: {}       // Node only. Pass to ONNX Runtime
 }): Promise<Ocr>
 
-ocr.detect(imagePath, { 
+ocr.detect(imagePath: string | {data: Uint8Array | Uint8ClampedArray | Buffer, width: number, height: number}, {
   onnxOptions?: {}     // Node only. Pass to ONNX Runtime
 }): Promise<{texts: TextLine[], resizedImageWidth: number, resizedImageHeight: number}>
 

--- a/packages/common/src/Ocr.ts
+++ b/packages/common/src/Ocr.ts
@@ -1,4 +1,4 @@
-import type { ModelCreateOptions } from '#common/types'
+import type { ImageRawData, ModelCreateOptions } from '#common/types'
 import { Detection, Recognition } from './models'
 
 export class Ocr {
@@ -22,7 +22,7 @@ export class Ocr {
     this.#recognition = recognition
   }
 
-  async detect(image: string, options = {}) {
+  async detect(image: string | ImageRawData, options = {}) {
     const { lineImages, resizedImageWidth, resizedImageHeight } = await this.#detection.run(image, options)
     const texts = await this.#recognition.run(lineImages, options)
     return {

--- a/packages/common/src/models/Detection.ts
+++ b/packages/common/src/models/Detection.ts
@@ -1,7 +1,7 @@
 import type { InferenceSession as InferenceSessionCommon, Tensor } from 'onnxruntime-common'
 import invariant from 'tiny-invariant'
 import { ImageRaw, InferenceSession, defaultModels, splitIntoLineImages } from '#common/backend'
-import type { ImageRaw as ImageRawType, ModelCreateOptions, Size } from '#common/types'
+import type { ImageRawData, ImageRaw as ImageRawType, ModelCreateOptions, Size } from '#common/types'
 import { ModelBase } from './ModelBase'
 
 const BASE_SIZE = 32
@@ -14,8 +14,8 @@ export class Detection extends ModelBase {
     return new Detection({ model, options: restOptions })
   }
 
-  async run(path: string, { onnxOptions = {} }: { onnxOptions?: InferenceSessionCommon.RunOptions } = {}) {
-    const image = await ImageRaw.open(path)
+  async run(path: string | ImageRawData, { onnxOptions = {} }: { onnxOptions?: InferenceSessionCommon.RunOptions } = {}) {
+    const image = typeof path === "string" ? await ImageRaw.open(path) : new ImageRaw(path)
 
     // Resize image to multiple of 32
     //   - image width and height must be a multiple of 32


### PR DESCRIPTION
Example code:
```js
const ocr = await Ocr.create();
const img = await Jimp.read("test.png");
const result = await ocr.detect(img.bitmap);
console.log(result);
```
This also probably fixes #34 